### PR TITLE
Change the way data is written to the temporary ts segment.

### DIFF
--- a/src/logic/convert-hls-to-mp4.ts
+++ b/src/logic/convert-hls-to-mp4.ts
@@ -66,12 +66,12 @@ export async function convertHlsToMP4(
         retryAsync<void>(async () => {
           const path = `${hash}-${i}.ts`
           let response = await fetchFile(segment.uri);
-          response =
-            indexOfIEND(response) !== 1
-              ? response.slice(indexOfIEND(response))
-              : response;
+          let response = await fetchFile(segment.uri);
+          const iendIdx = indexOfIEND(response);
+          if (iendIdx !== -1) {
+            response = response.slice(iendIdx);
+          }
           await ffmpeg.writeFile(path, response);
-          segment.uri = path
           downloaded++
           timeCurrent += segment.duration
           onProgress(

--- a/src/logic/convert-hls-to-mp4.ts
+++ b/src/logic/convert-hls-to-mp4.ts
@@ -32,7 +32,7 @@ export async function convertHlsToMP4(
 
   const hash = sha256(m3u8Content)
   const manifest = parse(m3u8Content)
-    
+
   if (!("segments" in manifest))
     throw new Error("Can't support master playlist")
 
@@ -66,7 +66,6 @@ export async function convertHlsToMP4(
         retryAsync<void>(async () => {
           const path = `${hash}-${i}.ts`
           let response = await fetchFile(segment.uri);
-          let response = await fetchFile(segment.uri);
           const iendIdx = indexOfIEND(response);
           if (iendIdx !== -1) {
             response = response.slice(iendIdx);
@@ -98,10 +97,10 @@ export async function convertHlsToMP4(
 
   return mp4Data
 }
-const IEND_IMAGE = Uint8Array.from([
+const IEND_IMAGE = new Uint8Array([
   0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
 ]);
-function indexOfIEND(buf: Uint8Array<ArrayBufferLike>): number {
+function indexOfIEND(buf: Uint8Array): number {
   for (let i = 0; i < buf.length - IEND_IMAGE.length; i++) {
     let found = true;
     for (let j = 0; j < IEND_IMAGE.length; j++) {

--- a/src/logic/convert-hls-to-mp4.ts
+++ b/src/logic/convert-hls-to-mp4.ts
@@ -32,11 +32,6 @@ export async function convertHlsToMP4(
 
   const hash = sha256(m3u8Content)
   const manifest = parse(m3u8Content)
-
-  const IEND_IMAGE = Uint8Array.from([
-  0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
-  ]);
-
     
   if (!("segments" in manifest))
     throw new Error("Can't support master playlist")
@@ -103,6 +98,9 @@ export async function convertHlsToMP4(
 
   return mp4Data
 }
+const IEND_IMAGE = Uint8Array.from([
+  0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+]);
 function indexOfIEND(buf: Uint8Array<ArrayBufferLike>): number {
   for (let i = 0; i < buf.length - IEND_IMAGE.length; i++) {
     let found = true;

--- a/src/logic/convert-hls-to-mp4.ts
+++ b/src/logic/convert-hls-to-mp4.ts
@@ -6,7 +6,6 @@ import pLimit from "p-limit"
 import sha256 from "sha256"
 import type { RetryOptions } from "ts-retry"
 import { retryAsync } from "ts-retry"
-
 /**
  * Converts an HLS (HTTP Live Streaming) manifest to an MP4 file.
  *
@@ -34,6 +33,11 @@ export async function convertHlsToMP4(
   const hash = sha256(m3u8Content)
   const manifest = parse(m3u8Content)
 
+  const IEND_IMAGE = Uint8Array.from([
+  0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+  ]);
+
+    
   if (!("segments" in manifest))
     throw new Error("Can't support master playlist")
 

--- a/src/logic/convert-hls-to-mp4.ts
+++ b/src/logic/convert-hls-to-mp4.ts
@@ -6,6 +6,7 @@ import pLimit from "p-limit"
 import sha256 from "sha256"
 import type { RetryOptions } from "ts-retry"
 import { retryAsync } from "ts-retry"
+
 /**
  * Converts an HLS (HTTP Live Streaming) manifest to an MP4 file.
  *
@@ -71,6 +72,7 @@ export async function convertHlsToMP4(
             response = response.slice(iendIdx);
           }
           await ffmpeg.writeFile(path, response);
+          segment.uri = path
           downloaded++
           timeCurrent += segment.duration
           onProgress(


### PR DESCRIPTION
### **User description**
If I write the original data fetched from fetchFile it won't read the ts segment to combine into mp4, so I split the image and ts segment. Then write the ts segment and it works.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix TS segment processing by separating image and video data

- Add IEND marker detection to properly split combined data

- Ensure FFmpeg can correctly read TS segments for MP4 conversion


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Fetch segment data"] --> B["Detect IEND marker"]
  B --> C["Split image/TS data"]
  C --> D["Write TS segment to FFmpeg"]
  D --> E["Convert to MP4"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>convert-hls-to-mp4.ts</strong><dd><code>Separate image data from TS segments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/logic/convert-hls-to-mp4.ts

<ul><li>Modified segment processing to detect and split image data from TS <br>segments<br> <li> Added <code>indexOfIEND</code> function to find PNG IEND markers in binary data<br> <li> Updated file writing logic to use processed TS data instead of raw <br>response</ul>


</details>


  </td>
  <td><a href="https://github.com/anime-vsub/desktop-web/pull/162/files#diff-50489146bae6c79fcc7b5f2eecbe5422fcc2d89c0cc1153a3ae72b489d021b0e">+21/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

