### PR TITLE
refactor: update m3u8 source fetching logic

### DIFF
--- a/src/apis/runs/ajax/player-link.ts
+++ b/src/apis/runs/ajax/player-link.ts
@@ -1,10 +1,11 @@
-import { C_URL } from "src/constants"
-import { decryptM3u8, init } from "src/logic/decrypt-hls-animevsub"
+// import { C_URL } from "src/constants"
 import { getQualityByLabel } from "src/logic/get-quality-by-label"
-// import { post } from "src/logic/http"
+import { post } from "src/logic/http"
+import { getSourceM3u8 } from "src/logic/get-source-m3u8"
+import { decryptM3u8 } from "src/logic/decrypt-hls-animevsub"
 
-const addProtocolUrl = (file: string) =>
-  file.startsWith("http") ? file : `https:${file}`
+// const addProtocolUrl = (file: string) =>
+//   file.startsWith("http") ? file : `https:${file}`
 
 interface PlayerLinkReturn {
   readonly link: {
@@ -31,7 +32,7 @@ interface PlayerLinkReturn {
       | "webm"
       | "youtube"
   }[]
-  readonly playTech: "api" | "trailer"
+  readonly playTech: "api" | "trailer" | "iframe"
 }
 
 type Writeable<T> = {
@@ -45,55 +46,43 @@ export function PlayerLink(config: {
 }): Promise<PlayerLinkReturn> {
   const { id, play, hash: link } = config
   //  "#animevsub-vsub" + "_extra"
-  // return post("/ajax/player?v=2019a", {
-  //   id,
-  //   play,
-  //   link,
-  //   backuplinks: "1"
-  // }).then(({ data }) => {
-  return fetch(`${C_URL}/ajax/player?v=2019a#animevsub-vsub_extra`, {
-    method: "post",
-    body: new URLSearchParams({ id, play, link, backuplinks: "1" })
+  return post("/ajax/player", {
+    id,
+    play,
+    link,
+    backuplinks: "1"
+  }).then(async ({ data }) => {
+    // return fetch(`${C_URL}/ajax/player?v=2019a#animevsub-vsub_extra`, {
+    //   method: "post",
+    //   body: new URLSearchParams({ id, play, link, backuplinks: "1" })
+    // })
+    //   .then((res) => res.json() as Promise<Writeable<PlayerLinkReturn>>)
+    //   .then(async (config) => {
+    const config = JSON.parse(data)
+    if (!config.link)
+      throw Object.assign(new Error("This server not found."), {
+        not_found: true
+      })
+
+    if (config.playTech === "iframe") {
+      const { m3u8: encryptedM3u8, headers } = await getSourceM3u8(config.link)
+
+      const isEncrypted = encryptedM3u8.match(/[?&]_c=[0-9]+/)
+      let finalM3u8 = ""
+
+      if (isEncrypted) {
+        finalM3u8 = await decryptM3u8(encryptedM3u8, headers)
+      }
+      config.link = [
+        {
+          file: `data:application/vnd.apple.mpegurl;base64,${btoa(unescape(encodeURIComponent(finalM3u8)))}`,
+          label: "FHD|HD",
+          preload: "auto",
+          type: "hls"
+        }
+      ]
+    }
+
+    return config
   })
-    .then((res) => res.json() as Promise<Writeable<PlayerLinkReturn>>)
-    .then(async (config) => {
-      if (!config.link)
-        throw Object.assign(new Error("This server not found."), {
-          not_found: true
-        })
-
-      await Promise.all(
-        config.link.map(async (item) => {
-          if (item.file.includes("://")) {
-            item.file = addProtocolUrl(item.file)
-          } else {
-            await init()
-            item.file = `data:application/vnd.apple.mpegurl;base64,${btoa(
-              await decryptM3u8(item.file)
-            )}`
-
-            item.label = "HD"
-            item.preload = "auto"
-            item.type = "hls"
-          }
-
-          switch (
-            (item.label as typeof item.label | undefined)?.toUpperCase() as
-              | Uppercase<Exclude<typeof item.label, undefined>>
-              | undefined
-          ) {
-            case "HD":
-              if (item.preload) item.label = "FHD|HD"
-              break
-            case undefined:
-              item.label = "HD"
-              break
-          }
-          item.qualityCode = getQualityByLabel(item.label)
-          item.type ??= "mp4"
-        })
-      )
-
-      return config
-    })
 }

--- a/src/components/comments/index.vue
+++ b/src/components/comments/index.vue
@@ -1,0 +1,524 @@
+<template>
+  <div class="comments-wrapper mt-8 text-gray-200 font-sans">
+    <div class="flex items-center justify-between mb-6">
+      <h3 class="text-[18px] font-medium text-white m-0">
+        {{ t("binh-luan") }}
+        <span class="text-gray-400 text-sm font-normal ml-1"
+          >({{ totalComments }})</span
+        >
+      </h3>
+    </div>
+
+    <div class="flex gap-3 mb-8">
+      <img
+        src="https://ui-avatars.com/api/?name=Me&background=2d3748&color=fff"
+        alt="Your Avatar"
+        class="w-10 h-10 rounded-full object-cover shrink-0 bg-dark-800"
+      />
+      <div class="flex-1">
+        <textarea
+          rows="2"
+          :placeholder="t('viet-binh-luan')"
+          class="w-full bg-[rgba(28,28,30,0.9)] border border-gray-700 rounded-lg p-3 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-main resize-none transition-colors"
+        ></textarea>
+        <div class="flex justify-end mt-2">
+          <q-btn
+            no-caps
+            unelevated
+            color="main"
+            text-color="white"
+            class="rounded-md font-medium px-4"
+            :label="t('gui-binh-luan')"
+          />
+        </div>
+      </div>
+    </div>
+
+    <div class="space-y-6">
+      <div
+        v-for="comment in commentsList"
+        :key="comment.id"
+        class="flex gap-3 group"
+      >
+        <div class="shrink-0">
+          <img
+            :src="getAvatar(comment.user_avatar)"
+            :alt="comment.user_name"
+            class="w-10 h-10 rounded-full object-cover bg-dark-800"
+            @error="handleAvatarError"
+          />
+        </div>
+
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center gap-2 mb-1 flex-wrap">
+            <span
+              class="font-bold text-[15px]"
+              :class="comment.badges?.length ? 'text-red-500' : 'text-gray-200'"
+            >
+              {{ comment.user_name }}
+            </span>
+
+            <span
+              v-if="comment.badges && comment.badges.length > 0"
+              class="text-[10px] font-bold uppercase px-1.5 py-0.5 rounded flex items-center gap-1"
+              :style="{
+                backgroundColor: comment.badges[0].color + '33',
+                color: comment.badges[0].color
+              }"
+            >
+              <Icon
+                icon="fluent:shield-task-16-filled"
+                width="12"
+                height="12"
+              />
+              {{ comment.badges[0].name }}
+            </span>
+
+            <span
+              v-if="comment.thread_key && comment.thread_key !== '/'"
+              class="text-[10px] font-bold px-1.5 py-0.5 rounded flex items-center gap-1 bg-gray-700 text-gray-300"
+            >
+              <Icon
+                icon="fluent:video-clip-16-regular"
+                width="12"
+                height="12"
+              />
+              {{ t("tap-_chap", [comment.thread_key]) }}
+            </span>
+
+            <span
+              v-if="comment.is_global_pinned || comment.is_pinned"
+              class="text-[11px] text-gray-400 flex items-center gap-1"
+            >
+              <Icon icon="fluent:pin-16-filled" /> {{ t("da-ghim") }}
+            </span>
+
+            <span class="text-xs text-gray-500 ml-auto flex items-center gap-1">
+              {{ formatTime(comment.created_at) }}
+              <span v-if="comment.edited_at > 0" class="text-[10px] italic">
+                ({{ t("da-chinh-sua") }})
+              </span>
+            </span>
+          </div>
+
+          <div class="relative">
+            <div
+              class="text-sm text-gray-300 leading-relaxed mb-2 whitespace-pre-wrap break-words transition-all duration-300"
+              :class="{
+                'filter blur-md select-none pointer-events-none opacity-50':
+                  comment.is_spoiler == 1 && !comment.isRevealed
+              }"
+              v-html="renderContent(comment.content)"
+            ></div>
+
+            <div
+              v-if="comment.is_spoiler == 1 && !comment.isRevealed"
+              class="absolute inset-0 flex items-center justify-center"
+            >
+              <button
+                @click="comment.isRevealed = true"
+                class="bg-dark-800 border border-gray-600 hover:border-gray-500 hover:bg-dark-700 text-gray-200 px-3 py-1.5 rounded-full text-xs font-medium flex items-center gap-1 transition-colors shadow-lg"
+              >
+                <Icon
+                  icon="fluent:eye-show-16-regular"
+                  width="14"
+                  height="14"
+                />
+                {{ t("binh-luan-chua-spoiler-nhan-de-xem") }}
+              </button>
+            </div>
+          </div>
+
+          <div
+            class="flex items-center gap-4 text-xs font-medium text-gray-400"
+          >
+            <button
+              class="flex items-center gap-1 hover:text-white transition-colors"
+            >
+              <Icon
+                icon="fluent:thumb-like-20-regular"
+                width="16"
+                height="16"
+              />
+              <span v-if="comment.votes_up > 0">{{ comment.votes_up }}</span>
+              <span v-else>{{ t("thich") }}</span>
+            </button>
+            <button
+              class="flex items-center gap-1 hover:text-white transition-colors"
+            >
+              <Icon
+                icon="fluent:thumb-dislike-20-regular"
+                width="16"
+                height="16"
+              />
+              <span v-if="comment.votes_down > 0">{{
+                comment.votes_down
+              }}</span>
+            </button>
+            <button class="hover:text-white transition-colors">
+              {{ t("phan-hoi") }}
+            </button>
+
+            <button
+              class="ml-auto opacity-0 group-hover:opacity-100 hover:text-white transition-opacity"
+            >
+              <Icon
+                icon="carbon:overflow-menu-vertical"
+                width="16"
+                height="16"
+              />
+            </button>
+          </div>
+
+          <div
+            v-if="comment.replies && comment.replies.length > 0"
+            class="mt-4 ml-1 pl-4 border-l-2 border-[rgba(255,255,255,0.05)] space-y-4"
+          >
+            <div
+              v-for="reply in comment.replies"
+              :key="reply.id"
+              class="flex gap-2.5 group/reply"
+            >
+              <div class="shrink-0">
+                <img
+                  :src="getAvatar(reply.user_avatar)"
+                  :alt="reply.user_name"
+                  class="w-7 h-7 rounded-full object-cover bg-dark-800"
+                  @error="handleAvatarError"
+                />
+              </div>
+
+              <div class="flex-1 min-w-0">
+                <div class="flex items-center gap-2 mb-0.5 flex-wrap">
+                  <span
+                    class="font-bold text-[13px]"
+                    :class="
+                      reply.badges?.length ? 'text-red-500' : 'text-gray-200'
+                    "
+                  >
+                    {{ reply.user_name }}
+                  </span>
+
+                  <span
+                    v-if="reply.badges && reply.badges.length > 0"
+                    class="text-[9px] font-bold uppercase px-1.5 py-0.5 rounded flex items-center gap-1"
+                    :style="{
+                      backgroundColor: reply.badges[0].color + '33',
+                      color: reply.badges[0].color
+                    }"
+                  >
+                    <Icon
+                      icon="fluent:shield-task-16-filled"
+                      width="10"
+                      height="10"
+                    />
+                    {{ reply.badges[0].name }}
+                  </span>
+
+                  <span
+                    v-if="reply.thread_key && reply.thread_key !== '/'"
+                    class="text-[9px] font-bold px-1.5 py-0.5 rounded flex items-center gap-1 bg-gray-700 text-gray-300"
+                  >
+                    {{ t("tap-_chap", [reply.thread_key]) }}
+                  </span>
+
+                  <span
+                    class="text-[11px] text-gray-500 ml-auto flex items-center gap-1"
+                  >
+                    {{ formatTime(reply.created_at) }}
+                    <span v-if="reply.edited_at > 0" class="text-[9px] italic">
+                      ({{ t("da-chinh-sua") }})
+                    </span>
+                  </span>
+                </div>
+
+                <div class="relative">
+                  <div
+                    class="text-[13px] text-gray-300 leading-relaxed mb-1.5 whitespace-pre-wrap break-words transition-all duration-300"
+                    :class="{
+                      'filter blur-md select-none pointer-events-none opacity-50':
+                        reply.is_spoiler == 1 && !reply.isRevealed
+                    }"
+                    v-html="renderContent(reply.content)"
+                  ></div>
+
+                  <div
+                    v-if="reply.is_spoiler == 1 && !reply.isRevealed"
+                    class="absolute inset-0 flex items-center justify-start"
+                  >
+                    <button
+                      @click="reply.isRevealed = true"
+                      class="bg-dark-800 border border-gray-600 hover:bg-dark-700 text-gray-200 px-2 py-1 rounded-full text-[10px] font-medium flex items-center gap-1 transition-colors"
+                    >
+                      <Icon
+                        icon="fluent:eye-show-16-regular"
+                        width="12"
+                        height="12"
+                      />
+                      {{ t("xem-spoiler") }}
+                    </button>
+                  </div>
+                </div>
+
+                <div
+                  class="flex items-center gap-3 text-[11px] font-medium text-gray-400"
+                >
+                  <button
+                    class="flex items-center gap-1 hover:text-white transition-colors"
+                  >
+                    <Icon
+                      icon="fluent:thumb-like-20-regular"
+                      width="14"
+                      height="14"
+                    />
+                    <span v-if="reply.votes_up > 0">{{ reply.votes_up }}</span>
+                  </button>
+                  <button
+                    class="flex items-center gap-1 hover:text-white transition-colors"
+                  >
+                    <Icon
+                      icon="fluent:thumb-dislike-20-regular"
+                      width="14"
+                      height="14"
+                    />
+                    <span v-if="reply.votes_down > 0">{{
+                      reply.votes_down
+                    }}</span>
+                  </button>
+                  <button class="hover:text-white transition-colors">
+                    {{ t("phan-hoi") }}
+                  </button>
+
+                  <button
+                    class="ml-auto opacity-0 group-hover/reply:opacity-100 hover:text-white transition-opacity"
+                  >
+                    <Icon
+                      icon="carbon:overflow-menu-vertical"
+                      width="14"
+                      height="14"
+                    />
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div
+            v-if="comment.replies_count > (comment.replies?.length || 0)"
+            class="mt-3 ml-2"
+          >
+            <button
+              @click="loadReplies(comment)"
+              :disabled="comment.isLoadingReplies"
+              class="text-blue-400 hover:text-blue-300 text-xs font-bold flex items-center gap-1 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <Icon
+                v-if="!comment.isLoadingReplies"
+                icon="fluent:arrow-reply-down-16-regular"
+                width="16"
+                height="16"
+                class="scale-x-[-1]"
+              />
+              <Icon
+                v-else
+                icon="fluent:spinner-ios-16-regular"
+                class="animate-spin"
+                width="16"
+                height="16"
+              />
+              {{
+                t("xem-them-count-phan-hoi", [
+                  comment.replies_count - (comment.replies?.length || 0)
+                ])
+              }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div
+      v-if="isLoadingComments && commentsList.length === 0"
+      class="flex justify-center mt-10"
+    >
+      <q-spinner-dots color="main" size="40px" />
+    </div>
+
+    <div
+      v-if="hasMoreComments && commentsList.length > 0"
+      class="mt-8 text-center"
+    >
+      <q-btn
+        @click="loadMoreComments"
+        :loading="isLoadingComments"
+        no-caps
+        outline
+        rounded
+        color="grey-7"
+        class="text-gray-300 font-medium px-6"
+        :label="t('tai-them-binh-luan')"
+      >
+        <template v-slot:loading>
+          <q-spinner-dots class="on-left" /> {{ t("dang-tai") }}
+        </template>
+      </q-btn>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, watch } from "vue"
+import { Icon } from "@iconify/vue"
+import { get } from "src/logic/http"
+import { C_URL } from "src/constants"
+import { useI18n } from "vue-i18n"
+
+const { t } = useI18n()
+
+const props = defineProps<{
+  filmId: number | string
+}>()
+
+const commentsList = ref<any[]>([])
+const totalComments = ref(0)
+const hasMoreComments = ref(true)
+const currentOffset = ref(0)
+const isLoadingComments = ref(false)
+
+onMounted(() => {
+  if (props.filmId) {
+    loadMoreComments()
+  }
+})
+
+watch(
+  () => props.filmId,
+  () => {
+    commentsList.value = []
+    currentOffset.value = 0
+    hasMoreComments.value = true
+    totalComments.value = 0
+    loadMoreComments()
+  }
+)
+
+const loadMoreComments = async () => {
+  if (isLoadingComments.value || !hasMoreComments.value) return
+  isLoadingComments.value = true
+
+  try {
+    const response = await get({
+      url: `${C_URL}/ajax/comment?action=get&film_id=${props.filmId}&sort=newest&offset=${currentOffset.value}`,
+      responseType: "json"
+    })
+
+    const data = response.data as any
+    if (data.success) {
+      const newComments = data.comments.map((c: any) => ({
+        ...c,
+        replies: c.replies || [],
+        replies_offset: 0,
+        isLoadingReplies: false,
+        isRevealed: false
+      }))
+
+      commentsList.value.push(...newComments)
+      currentOffset.value = data.offset
+      hasMoreComments.value = data.has_more
+      totalComments.value = data.total
+    }
+  } catch (error) {
+    console.error("Lỗi khi tải bình luận:", error)
+  } finally {
+    isLoadingComments.value = false
+  }
+}
+
+const loadReplies = async (comment: any) => {
+  if (comment.isLoadingReplies) return
+  comment.isLoadingReplies = true
+
+  try {
+    const offset = comment.replies_offset || 0
+    const response = await get({
+      url: `${C_URL}/ajax/comment?action=get_replies&comment_id=${comment.id}&sort=newest&offset=${offset}`,
+      responseType: "json"
+    })
+
+    const data = response.data as any
+    if (data.success) {
+      if (!comment.replies) comment.replies = []
+
+      const newReplies = data.replies.map((r: any) => ({
+        ...r,
+        isRevealed: false
+      }))
+
+      comment.replies.push(...newReplies)
+      comment.replies_offset = data.offset
+
+      if (!data.has_more) {
+        comment.replies_count = comment.replies.length
+      }
+    }
+  } catch (error) {
+    console.error("Lỗi khi tải phản hồi:", error)
+  } finally {
+    comment.isLoadingReplies = false
+  }
+}
+
+const getAvatar = (url: string) => {
+  if (!url || url.includes("googleusercontent.com/profile/picture/")) {
+    return `https://ui-avatars.com/api/?name=User&background=2d3748&color=fff`
+  }
+  return url
+}
+
+const handleAvatarError = (e: Event) => {
+  ;(e.target as HTMLImageElement).src =
+    "https://ui-avatars.com/api/?name=Err&background=2d3748&color=fff"
+}
+
+const formatTime = (timestamp: number) => {
+  if (!timestamp) return ""
+  const date = new Date(timestamp * 1000)
+  return date.toLocaleDateString("vi-VN", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric"
+  })
+}
+
+const renderContent = (content: string) => {
+  if (!content) return ""
+
+  let html = content
+
+  const stickers: string[] = []
+  html = html.replace(/\[sticker:(.*?)\]/g, (match, url) => {
+    stickers.push(url)
+    return `__STICKER_${stickers.length - 1}__`
+  })
+
+  html = html.replace(/@\[?(.*?)\]?(?=\s|$)/g, (match, username) => {
+    return `<span class="text-blue-400 font-medium hover:underline cursor-pointer">@${username}</span>`
+  })
+
+  const urlRegex = /(https?:\/\/[^\s]+)/g
+  html = html.replace(
+    urlRegex,
+    '<a href="$1" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:underline break-all">$1</a>'
+  )
+
+  html = html.replace(/__STICKER_(\d+)__/g, (match, indexStr) => {
+    const url = stickers[parseInt(indexStr)]
+    if (url.includes("googleusercontent.com/profile/picture/")) {
+      return ` <span class="text-yellow-400">🌟(${t("sticker-loi")})</span> `
+    }
+    return `<img src="${url}" alt="sticker" class="inline-block h-12 w-12 ml-1 align-middle rounded" />`
+  })
+
+  return html
+}
+</script>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -59,4 +59,6 @@ export const NAME_GET_MEMORY = "get memory"
 
 export const API_PROXY = "http://localhost:8787"
 
+export const cdn_google = "https://storage.googleapiscdn.com"
+
 export const EMPTY_ARRAY = Object.freeze([])

--- a/src/i18n/messages/en-US.json
+++ b/src/i18n/messages/en-US.json
@@ -321,5 +321,15 @@
   "tai-video-that-bai": "Video download failed",
   "matte": "Wait!",
   "msg-warn": "If someone asks you to copy something here, 11/10 times you are being scammed.",
-  "msg-warn2": "Copying anything here can get your Google/Facebook/Discord and many other accounts hacked."
+  "msg-warn2": "Copying anything here can get your Google/Facebook/Discord and many other accounts hacked.",
+  "gui-binh-luan": "Post comment",
+  "da-ghim": "Pinned",
+  "da-chinh-sua": "edited",
+  "binh-luan-chua-spoiler-nhan-de-xem": "Comment contains a spoiler. Click to reveal.",
+  "thich": "Like",
+  "xem-spoiler": "Show spoiler",
+  "xem-them-count-phan-hoi": "View {0} more replies",
+  "tai-them-binh-luan": "Load more comments",
+  "dang-tai": "Loading...",
+  "sticker-loi": "Broken sticker"
 }

--- a/src/i18n/messages/vi-VN.json
+++ b/src/i18n/messages/vi-VN.json
@@ -311,5 +311,15 @@
   "chap-not-found": "Chap {0} not found",
   "matte": "Chờ đã!",
   "msg-warn": "Nếu có ai đó yêu cầu bạn sao/chép thứ gì đó ở đây, bảo đảm 11/10 lần là bạn đang bị lừa.",
-  "msg-warn2": "Sao chép bất cứ thứ gì vào đây có thể khiến tài khoản Google/Facebook/Discord và nhiều tài khoản khác của bạn bị tấn công."
+  "msg-warn2": "Sao chép bất cứ thứ gì vào đây có thể khiến tài khoản Google/Facebook/Discord và nhiều tài khoản khác của bạn bị tấn công.",
+  "gui-binh-luan": "Gửi bình luận",
+  "da-ghim": "Đã ghim",
+  "da-chinh-sua": "đã chỉnh sửa",
+  "binh-luan-chua-spoiler-nhan-de-xem": "Bình luận chứa Spoiler. Nhấn để xem",
+  "thich": "Thích",
+  "xem-spoiler": "Xem Spoiler",
+  "xem-them-count-phan-hoi": "Xem thêm {0} phản hồi",
+  "tai-them-binh-luan": "Tải thêm bình luận",
+  "dang-tai": "Đang tải...",
+  "sticker-loi": "Sticker lỗi"
 }

--- a/src/logic/convert-hls-to-mp4.ts
+++ b/src/logic/convert-hls-to-mp4.ts
@@ -66,12 +66,12 @@ export async function convertHlsToMP4(
         retryAsync<void>(async () => {
           const path = `${hash}-${i}.ts`
           let response = await fetchFile(segment.uri);
-          response =
-            indexOfIEND(response) !== 1
-              ? response.slice(indexOfIEND(response))
-              : response;
+          let response = await fetchFile(segment.uri);
+          const iendIdx = indexOfIEND(response);
+          if (iendIdx !== -1) {
+            response = response.slice(iendIdx);
+          }
           await ffmpeg.writeFile(path, response);
-          segment.uri = path
           downloaded++
           timeCurrent += segment.duration
           onProgress(

--- a/src/logic/convert-hls-to-mp4.ts
+++ b/src/logic/convert-hls-to-mp4.ts
@@ -32,7 +32,7 @@ export async function convertHlsToMP4(
 
   const hash = sha256(m3u8Content)
   const manifest = parse(m3u8Content)
-    
+
   if (!("segments" in manifest))
     throw new Error("Can't support master playlist")
 
@@ -66,7 +66,6 @@ export async function convertHlsToMP4(
         retryAsync<void>(async () => {
           const path = `${hash}-${i}.ts`
           let response = await fetchFile(segment.uri);
-          let response = await fetchFile(segment.uri);
           const iendIdx = indexOfIEND(response);
           if (iendIdx !== -1) {
             response = response.slice(iendIdx);
@@ -98,10 +97,10 @@ export async function convertHlsToMP4(
 
   return mp4Data
 }
-const IEND_IMAGE = Uint8Array.from([
+const IEND_IMAGE = new Uint8Array([
   0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
 ]);
-function indexOfIEND(buf: Uint8Array<ArrayBufferLike>): number {
+function indexOfIEND(buf: Uint8Array): number {
   for (let i = 0; i < buf.length - IEND_IMAGE.length; i++) {
     let found = true;
     for (let j = 0; j < IEND_IMAGE.length; j++) {

--- a/src/logic/convert-hls-to-mp4.ts
+++ b/src/logic/convert-hls-to-mp4.ts
@@ -32,11 +32,6 @@ export async function convertHlsToMP4(
 
   const hash = sha256(m3u8Content)
   const manifest = parse(m3u8Content)
-
-  const IEND_IMAGE = Uint8Array.from([
-  0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
-  ]);
-
     
   if (!("segments" in manifest))
     throw new Error("Can't support master playlist")
@@ -103,6 +98,9 @@ export async function convertHlsToMP4(
 
   return mp4Data
 }
+const IEND_IMAGE = Uint8Array.from([
+  0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+]);
 function indexOfIEND(buf: Uint8Array<ArrayBufferLike>): number {
   for (let i = 0; i < buf.length - IEND_IMAGE.length; i++) {
     let found = true;

--- a/src/logic/convert-hls-to-mp4.ts
+++ b/src/logic/convert-hls-to-mp4.ts
@@ -6,7 +6,6 @@ import pLimit from "p-limit"
 import sha256 from "sha256"
 import type { RetryOptions } from "ts-retry"
 import { retryAsync } from "ts-retry"
-
 /**
  * Converts an HLS (HTTP Live Streaming) manifest to an MP4 file.
  *
@@ -34,6 +33,11 @@ export async function convertHlsToMP4(
   const hash = sha256(m3u8Content)
   const manifest = parse(m3u8Content)
 
+  const IEND_IMAGE = Uint8Array.from([
+  0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+  ]);
+
+    
   if (!("segments" in manifest))
     throw new Error("Can't support master playlist")
 

--- a/src/logic/convert-hls-to-mp4.ts
+++ b/src/logic/convert-hls-to-mp4.ts
@@ -6,6 +6,7 @@ import pLimit from "p-limit"
 import sha256 from "sha256"
 import type { RetryOptions } from "ts-retry"
 import { retryAsync } from "ts-retry"
+
 /**
  * Converts an HLS (HTTP Live Streaming) manifest to an MP4 file.
  *
@@ -71,6 +72,7 @@ export async function convertHlsToMP4(
             response = response.slice(iendIdx);
           }
           await ffmpeg.writeFile(path, response);
+          segment.uri = path
           downloaded++
           timeCurrent += segment.duration
           onProgress(

--- a/src/logic/decrypt-hls-animevsub.ts
+++ b/src/logic/decrypt-hls-animevsub.ts
@@ -1,1 +1,150 @@
-export { init, decryptM3u8 } from "./dha/main"
+function base64ToUint8Array(base64Str: string): Uint8Array {
+  let cleaned = base64Str
+    .replace(/^W\/"|"/g, "")
+    .replace(/-/g, "+")
+    .replace(/_/g, "/")
+
+  while (cleaned.length % 4) {
+    cleaned += "="
+  }
+
+  const binary = atob(cleaned)
+  const bytes = new Uint8Array(binary.length)
+
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+
+  return bytes
+}
+
+export async function decrypt(
+  encryptedPayloadBase64: string,
+  etag: string,
+  proxyDigest: string,
+  cacheNode: string,
+  requestTrace: string
+): Promise<string> {
+  if (!window.crypto?.subtle) {
+    throw new Error("Web Crypto API not found.")
+  }
+  const keyBytes = base64ToUint8Array(etag)
+  const iv = keyBytes.slice(0, 12)
+
+  const hmacKey = await crypto.subtle.importKey(
+    "raw",
+    keyBytes as BufferSource,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  )
+
+  const encryptedBytes = base64ToUint8Array(encryptedPayloadBase64)
+  const msg = `${proxyDigest}:${requestTrace}:${cacheNode}`
+  try {
+    const messageBytes = new TextEncoder().encode(msg)
+    const hmacResult = await crypto.subtle.sign(
+      "HMAC",
+      hmacKey,
+      messageBytes as BufferSource
+    )
+    const aesKey = await crypto.subtle.importKey(
+      "raw",
+      hmacResult,
+      { name: "AES-GCM" },
+      false,
+      ["decrypt"]
+    )
+    const decryptedBuffer = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: iv },
+      aesKey,
+      encryptedBytes as BufferSource
+    )
+    return new TextDecoder().decode(decryptedBuffer)
+  } catch (e) {
+    throw new Error("Decrypt Error!!!")
+  }
+}
+
+export async function decryptM3u8(
+  encryptedM3u8: string,
+  headers: Record<string, string>
+): Promise<string> {
+  const edge_tag = headers["x-edge-tag"] || ""
+  const proxyDigest = headers["x-proxy-digest"] || ""
+  const cacheNode = decodeURIComponent(headers["x-cache-node"] || "")
+  const requestTrace = headers["x-request-trace"] || "0"
+
+  if (!edge_tag || !proxyDigest || !cacheNode || !requestTrace) {
+    throw new Error("Missing item in headers.")
+  }
+
+  const lines = encryptedM3u8.split("\n")
+
+  const cleanLines: string[] = []
+  const encryptedTokens: string[] = []
+
+  let baseParams = ""
+
+  const paramsMatch = encryptedM3u8.match(/(si=\d+&seq=\d+&token=[^&\s]+)/)
+
+  if (paramsMatch) {
+    baseParams = paramsMatch[1]
+  }
+
+  for (const line of lines) {
+    if (line.startsWith("#") || line.trim() === "") {
+      if (!line.match(/^#EXTINF:/) && !line.match(/^#EXT-X-ENDLIST/)) {
+        cleanLines.push(line)
+      }
+    } else {
+      const match = line.match(/[?&]_t=([^&\s]+)/)
+      if (match) {
+        encryptedTokens.push(match[1])
+      }
+    }
+  }
+  const combinedEncryptedPayload = encryptedTokens.join("")
+
+  if (!combinedEncryptedPayload) {
+    return encryptedM3u8
+  }
+
+  const decryptedContent = await decrypt(
+    combinedEncryptedPayload,
+    edge_tag,
+    proxyDigest,
+    cacheNode,
+    requestTrace
+  )
+
+  const parsedBaseParams = new URLSearchParams(baseParams)
+
+  const finalLines = decryptedContent.split("\n").map((line) => {
+    if (line.trim() === "" || line.startsWith("#")) {
+      return line
+    }
+
+    let finalUrl = line
+
+    if (finalUrl.startsWith("/")) {
+      finalUrl = cdn_google + finalUrl
+    } else if (!finalUrl.startsWith("http")) {
+      finalUrl = cdn_google + "/" + finalUrl
+    }
+
+    try {
+      const urlObj = new URL(finalUrl)
+      parsedBaseParams.forEach((value, key) => {
+        if (!urlObj.searchParams.has(key)) {
+          urlObj.searchParams.set(key, value)
+        }
+      })
+      return urlObj.toString()
+    } catch (e) {
+      console.warn("URL Parse Error:", line)
+      return finalUrl
+    }
+  })
+  return cleanLines.join("\n") + "\n" + finalLines.join("\n")
+}

--- a/src/logic/get-source-m3u8.ts
+++ b/src/logic/get-source-m3u8.ts
@@ -1,0 +1,31 @@
+import { get } from "src/logic/http"
+
+export async function getSourceM3u8(
+  link: string
+): Promise<{ m3u8: string; headers: Record<string, string> }> {
+  const htmlRes = await get({
+    url: `${link}#animevsub-vsubo`,
+    responseType: "text"
+  })
+  const html = htmlRes.data as string
+
+  const idRegex = /const\s+id\s*=\s*["']([^"']+)["']/i
+  const tokenRegex = /const\s+avsToken\s*=\s*["']([^"']+)["']/i
+
+  const idMatch = html.match(idRegex)
+  const tokenMatch = html.match(tokenRegex)
+
+  const id = idMatch ? idMatch[1] : null
+  const avsToken = tokenMatch ? tokenMatch[1] : null
+
+  const m3u8Response = await get({
+    url: `${cdn_google}/playlist/${id}/playlist.m3u8?token=${avsToken}#animevsub-vsubo`,
+    responseType: "text"
+  })
+
+  const m3u8 = m3u8Response.data as string
+  return {
+    m3u8,
+    headers: m3u8Response.headers
+  }
+}

--- a/src/pages/phim/_season.vue
+++ b/src/pages/phim/_season.vue
@@ -390,11 +390,12 @@
       </div>
 
       <!-- comment embed -->
-      <FbComments
+      <Comments v-if="seasonId" :film-id="seasonId" />
+      <!-- <FbComments
         v-if="semverGt(Http.version, '1.0.29')"
         :href="`http://animevietsub.tv/phim/-${seasonId}/`"
         :lang="locale?.replace('-', '_')"
-      />
+      /> -->
       <template v-else>
         <div class="mt-5 flex items-center justify-between flex-nowrap">
           <span class="text-subtitle1 text-[#eee]">{{ t("binh-luan") }}</span>
@@ -495,6 +496,7 @@ import ScreenError from "components/ScreenError.vue"
 import SkeletonCardVertical from "components/SkeletonCardVertical.vue"
 import Star from "components/Star.vue"
 import FbComments from "components/fb-comments/index.vue"
+import Comments from "components/comments/index.vue"
 import MessageScheludeChap from "components/feat/MessageScheludeChap.vue"
 import { EmbedFbCmt } from "embed-fbcmt-client/vue"
 import { set } from "idb-keyval"


### PR DESCRIPTION
**Changes:**
* `src/apis/runs/ajax/player-link.ts`: Use a POST request to fetch `/ajax/player` from the server, then decrypt it using the new `decryptM3u8` function to retrieve the original source.
* `src/constants.ts`: Add the `cdn_google` variable to store the Google Storage CDN address.
* `src/logic/decrypt-hls-animevsub.ts`: Replace the old WASM decryption with the new AES-GCM decryption method.

**Added:**
* `src/logic/get-source-m3u8.ts`: Add the `getSourceM3u8` function to extract the source, IV, and salt via the iframe player.