### PR TITLE
fix: handle CSRF token requirement on login endpoint

### DIFF
--- a/src/apis/runs/dang-nhap.ts
+++ b/src/apis/runs/dang-nhap.ts
@@ -7,26 +7,33 @@ import { Md5 } from "ts-md5"
 
 import { PostWorker } from "../wrap-worker"
 
+const LOGIN_URL = `/account/login/?_fxRef=${C_URL}/account/info`
+
 export async function DangNhap(email: string, password: string) {
   // eslint-disable-next-line camelcase
   const password_md5 = Md5.hashAsciiStr(password)
+  const body = {
+    email,
+    password: "",
+    // eslint-disable-next-line camelcase
+    password_md5,
+    save_password: "1",
+    submit: ""
+  }
 
-  const { data: html, headers } = await post(
-    `/account/login/?_fxRef=${C_URL}/account/info`,
-    {
-      email,
-      password: "",
-      // eslint-disable-next-line camelcase
-      password_md5,
-      save_password: "1",
-      submit: ""
-    }
-  )
+  // First POST without _csrf: server rejects but returns login page HTML containing a fresh _csrf token
+  const { data: loginPage } = await post(LOGIN_URL, body)
+  const csrfMatch = loginPage.match(/name="_csrf"[^>]*value="([^"]+)"/)
+  if (!csrfMatch) throw new Error(i18n.global.t("dang-nhap-that-bai"))
+
+  // Second POST with the extracted _csrf: server should authenticate and return the logged-in page
+  const { data: html, headers } = await post(LOGIN_URL, {
+    ...body,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    _csrf: csrfMatch[1]
+  })
 
   if (html.includes("user-name-text")) {
-    // login success
-    // parse
-
     return {
       ...(await PostWorker<typeof AccountInfoParser>(Worker, html)),
       cookie:

--- a/src/apis/runs/dang-nhap.ts
+++ b/src/apis/runs/dang-nhap.ts
@@ -22,26 +22,28 @@ export async function DangNhap(email: string, password: string) {
   }
 
   // First POST without _csrf: server rejects but returns login page HTML containing a fresh _csrf token
-  const { data: loginPage } = await post(LOGIN_URL, body)
+  const { data: loginPage, headers: firstHeaders } = await post(LOGIN_URL, body)
   const csrfMatch = loginPage.match(/name="_csrf"[^>]*value="([^"]+)"/)
   if (!csrfMatch) throw new Error(i18n.global.t("dang-nhap-that-bai"))
 
+  const sessionCookie = new Headers(firstHeaders).get("set-cookie")
+
   // Second POST with the extracted _csrf: server should authenticate and return the logged-in page
-  const { data: html, headers } = await post(LOGIN_URL, {
-    ...body,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    _csrf: csrfMatch[1]
-  })
+  const { data: html, headers } = await post(
+    LOGIN_URL,
+    {
+      ...body,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      _csrf: csrfMatch[1]
+    },
+    sessionCookie ? { cookie: sessionCookie } : undefined
+  )
 
   if (html.includes("user-name-text")) {
     return {
       ...(await PostWorker<typeof AccountInfoParser>(Worker, html)),
-      cookie:
-        new Headers(headers).get("set-cookie") ??
-        document.cookie
-          .split(";")
-          .map((item) => item.trim())
-          .join(",")
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      cookie: new Headers(headers).get("set-cookie")!
     }
   } else {
     throw new Error(i18n.global.t("dang-nhap-that-bai"))


### PR DESCRIPTION
## Problem

Login stopped working with the generic `"Đăng nhập thất bại"` error. The root cause is a server-side change on `animevietsub.bz`: the `POST /account/login/` endpoint now requires a `_csrf` token that is embedded as a hidden field in the login page HTML and bound to the PHP session. Without it the server rejects the credentials and re-renders the login form, so the `user-name-text` substring is never present in the response and `DangNhap` always throws.

The previous code sent only `{ email, password, password_md5, save_password, submit }` with no `_csrf`, which had always worked until this server-side change.

## Why two POSTs instead of GET + POST

The natural fix would be to `GET /account/login/` first to obtain a fresh `_csrf`, then `POST` with it. However, the server (behind Cloudflare) blocks `GET` requests originating from the extension's background service worker — the request originates with `Origin: chrome-extension://…` and is rejected before returning a response (`TypeError: Failed to fetch`). `POST` requests from the same context are accepted.

The workaround is to send a first `POST` without `_csrf` — the server rejects the credentials but still returns a `200` with the login form HTML containing a fresh `_csrf` token. We extract that token and immediately fire a second `POST` with it, which authenticates successfully.

## Changes

- `src/apis/runs/dang-nhap.ts` — two-POST flow: first POST harvests `_csrf` from the re-rendered login page, second POST submits credentials with the token.

## Demo


https://github.com/user-attachments/assets/976f98ef-a199-4e09-a946-f206b55299b2

